### PR TITLE
feat: 사용자 관리 페이지 구현

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -1,17 +1,121 @@
-"""
-Authentication API routes (PKCE Flow - JWT Bearer Token)
-"""
-from fastapi import APIRouter, Request, HTTPException
+"""인증 및 사용자 역할 관리 API 라우터 (PKCE Flow - JWT Bearer Token)."""
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from pydantic import BaseModel, EmailStr
 
-from app.core.deps import get_current_user
+from app.core.deps import get_current_user, get_role_service, require_admin
 
 router = APIRouter(prefix="/auth")
 
 
-@router.get("/me")
+class UserResponse(BaseModel):
+    """인증된 사용자 정보 응답."""
+
+    user_id: str
+    name: str
+    email: str
+    tenant_id: str
+    role: str
+
+
+class UpdateRoleRequest(BaseModel):
+    """역할 변경 요청."""
+
+    email: EmailStr
+    role: str
+
+
+class AddUserRequest(BaseModel):
+    """사용자 추가 요청."""
+
+    email: EmailStr
+    role: str = "user"
+    name: str = ""
+
+
+class PortalUserResponse(BaseModel):
+    """포털 사용자 정보 응답."""
+
+    user_id: str
+    name: str
+    email: str
+    role: str
+    registered_at: str
+
+
+@router.get("/me", response_model=UserResponse)
 async def get_current_user_info(request: Request):
-    """Get current authenticated user info from JWT token"""
+    """현재 인증된 사용자 정보와 역할을 반환한다."""
     user = get_current_user(request)
     if not user:
         raise HTTPException(status_code=401, detail="Not authenticated")
-    return user
+    return UserResponse(
+        user_id=user.get("user_id", ""),
+        name=user.get("name", ""),
+        email=user.get("email", ""),
+        tenant_id=user.get("tenant_id", ""),
+        role=user.get("role", "user"),
+    )
+
+
+@router.get("/users", response_model=list[PortalUserResponse])
+async def list_portal_users(
+    _admin=Depends(require_admin),
+    role_svc=Depends(get_role_service),
+):
+    """모든 포털 사용자 목록을 조회한다 (Admin 전용)."""
+    users = await role_svc.get_all_users()
+    return [PortalUserResponse(**u) for u in users]
+
+
+@router.post("/users", response_model=PortalUserResponse, status_code=201)
+async def add_user(
+    body: AddUserRequest,
+    _admin=Depends(require_admin),
+    role_svc=Depends(get_role_service),
+):
+    """포털 접근 허용 사용자를 추가한다 (Admin 전용).
+
+    Args:
+        body: 추가할 사용자 정보 (email, role, name).
+    """
+    if body.role not in ("admin", "user"):
+        raise HTTPException(
+            status_code=400, detail="Role must be 'admin' or 'user'"
+        )
+    user_data = await role_svc.add_user(
+        email=body.email, role=body.role, name=body.name
+    )
+    return PortalUserResponse(**user_data)
+
+
+@router.delete("/users", status_code=204)
+async def remove_user(
+    email: str = Query(..., description="삭제할 사용자 이메일"),
+    _admin=Depends(require_admin),
+    role_svc=Depends(get_role_service),
+):
+    """포털 접근 허용 사용자를 제거한다 (Admin 전용).
+
+    Args:
+        email: 제거할 사용자 이메일.
+    """
+    await role_svc.remove_user(email)
+
+
+@router.patch("/users/role", response_model=PortalUserResponse)
+async def update_user_role(
+    body: UpdateRoleRequest,
+    _admin=Depends(require_admin),
+    role_svc=Depends(get_role_service),
+):
+    """사용자의 역할을 변경한다 (Admin 전용).
+
+    Args:
+        body: 대상 사용자 email과 새 역할 정보.
+    """
+    if body.role not in ("admin", "user"):
+        raise HTTPException(
+            status_code=400, detail="Role must be 'admin' or 'user'"
+        )
+    updated_user = await role_svc.update_user_role(body.email, body.role)
+    return PortalUserResponse(**updated_user)

--- a/backend/app/core/deps.py
+++ b/backend/app/core/deps.py
@@ -1,50 +1,88 @@
+"""FastAPI 의존성 주입 팩토리.
+
+각 서비스 싱글턴 인스턴스를 FastAPI의 ``Depends()``를 통해 제공한다.
 """
-FastAPI dependencies for dependency injection
-"""
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from fastapi import Request
-from app.services.storage import storage_service
-from app.services.entra_id import entra_id_service
-from app.services.resource_manager import resource_manager_service
-from app.services.policy import policy_service
+
+from app.exceptions import AuthorizationError
 from app.services.cost import cost_service
 from app.services.email import email_service
+from app.services.entra_id import entra_id_service
+from app.services.policy import policy_service
+from app.services.resource_manager import resource_manager_service
+from app.services.role import role_service
+from app.services.storage import storage_service
 
 
 def get_storage_service():
-    """Get storage service instance"""
+    """StorageService 싱글턴을 반환한다."""
     return storage_service
 
 
 def get_entra_id_service():
-    """Get Entra ID service instance"""
+    """EntraIDService 싱글턴을 반환한다."""
     return entra_id_service
 
 
 def get_resource_manager_service():
-    """Get Resource Manager service instance"""
+    """ResourceManagerService 싱글턴을 반환한다."""
     return resource_manager_service
 
 
 def get_policy_service():
-    """Get Policy service instance"""
+    """PolicyService 싱글턴을 반환한다."""
     return policy_service
 
 
 def get_cost_service():
-    """Get Cost Management service instance"""
+    """CostService 싱글턴을 반환한다."""
     return cost_service
 
 
 def get_email_service():
-    """Get Email service instance"""
+    """EmailService 싱글턴을 반환한다."""
     return email_service
 
 
-def get_current_user(request: Request) -> Optional[Dict[str, Any]]:
-    """
-    Get current authenticated user from request state (set by JWT middleware)
-    Returns None if not authenticated
+def get_role_service():
+    """RoleService 싱글턴을 반환한다."""
+    return role_service
+
+
+def get_current_user(request: Request) -> Optional[dict[str, Any]]:
+    """JWT 미들웨어가 설정한 현재 인증 사용자를 반환한다.
+
+    Args:
+        request: FastAPI 요청 객체.
+
+    Returns:
+        인증된 경우 사용자 정보 딕셔너리, 아니면 None.
     """
     return getattr(request.state, "user", None)
+
+
+def require_admin(request: Request) -> dict[str, Any]:
+    """현재 사용자가 Admin 역할인지 검증한다.
+
+    Admin 전용 엔드포인트의 의존성으로 사용한다.
+
+    Args:
+        request: FastAPI 요청 객체.
+
+    Returns:
+        Admin 사용자 정보 딕셔너리.
+
+    Raises:
+        AuthorizationError: 사용자가 Admin이 아닌 경우.
+    """
+    user = getattr(request.state, "user", None)
+    if not user:
+        raise AuthorizationError("Authentication required")
+
+    if user.get("role") != "admin":
+        raise AuthorizationError(
+            "Admin privileges required to access this resource"
+        )
+    return user

--- a/backend/app/exceptions/__init__.py
+++ b/backend/app/exceptions/__init__.py
@@ -37,8 +37,8 @@ Exception Hierarchy:
     │       │   ├── RoleAssignmentError
     │       │   └── DeploymentError
     │       ├── StorageServiceError
-    │       │   ├── BlobNotFoundError (404)
-    │       │   └── ContainerNotFoundError (404)
+    │       │   ├── EntityNotFoundError (404)
+    │       │   └── TableNotFoundError (404)
     │       ├── EntraIDServiceError (formerly AzureADServiceError)
     │       │   ├── EntraIDAuthorizationError (403)
     │       │   ├── UserCreationError
@@ -74,8 +74,8 @@ from .azure import (
     RoleAssignmentError,
     DeploymentError,
     StorageServiceError,
-    BlobNotFoundError,
-    ContainerNotFoundError,
+    EntityNotFoundError,
+    TableNotFoundError,
     EntraIDServiceError,
     EntraIDAuthorizationError,
     UserCreationError,
@@ -116,8 +116,8 @@ __all__ = [
     "RoleAssignmentError",
     "DeploymentError",
     "StorageServiceError",
-    "BlobNotFoundError",
-    "ContainerNotFoundError",
+    "EntityNotFoundError",
+    "TableNotFoundError",
     "EntraIDServiceError",
     "EntraIDAuthorizationError",
     "UserCreationError",

--- a/backend/app/middleware/auth.py
+++ b/backend/app/middleware/auth.py
@@ -1,15 +1,16 @@
-"""
-Authentication middleware for JWT Bearer token validation (PKCE Flow)
-"""
+"""JWT Bearer 토큰 인증 미들웨어 (PKCE Flow)."""
 import logging
+
 from fastapi import Request
 from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
+
 from app.services.jwt_validator import jwt_service
+from app.services.role import role_service
 
 logger = logging.getLogger(__name__)
 
-PUBLIC_PATHS = [
+PUBLIC_PATH_PREFIXES = (
     "/health",
     "/static",
     "/assets",
@@ -18,62 +19,80 @@ PUBLIC_PATHS = [
     "/docs",
     "/openapi.json",
     "/redoc",
-]
+)
 
 
 class AuthMiddleware(BaseHTTPMiddleware):
+    """API 라우트에 JWT Bearer 토큰 인증을 적용하는 미들웨어.
+
+    프론트엔드는 MSAL (PKCE flow)을 통해 인증을 수행한다.
+    인증 성공 후 Table Storage에서 사용자 역할을 조회하여 부여한다.
     """
-    Middleware to enforce JWT Bearer token authentication on API routes
-    Frontend handles authentication via MSAL (PKCE flow)
-    """
-    
+
     async def dispatch(self, request: Request, call_next):
+        """요청을 가로채어 인증을 검증한다."""
         path = request.url.path
-        
-        if self._is_public_path(path):
+
+        if self._is_public_path(path) or not path.startswith("/api/"):
             return await call_next(request)
-        
-        if not path.startswith("/api/"):
-            return await call_next(request)
-        
+
         auth_header = request.headers.get("Authorization")
-        
+
         if not auth_header or not auth_header.startswith("Bearer "):
-            logger.info(f"Missing or invalid Authorization header for {path}")
+            logger.info("Missing or invalid Authorization header for %s", path)
             return JSONResponse(
                 status_code=401,
-                content={"detail": "Not authenticated"}
+                content={"detail": "Not authenticated"},
             )
-        
+
         token = auth_header.split(" ", 1)[1]
-        
         claims = await jwt_service.validate_token(token)
-        
+
         if not claims:
-            logger.warning(f"Invalid token for {path}")
+            logger.warning("Invalid token for %s", path)
             return JSONResponse(
                 status_code=401,
-                content={"detail": "Invalid or expired token"}
+                content={"detail": "Invalid or expired token"},
             )
-        
+
         user_info = jwt_service.get_user_info_from_claims(claims)
-        
+
         if not jwt_service.validate_user_domain(user_info.get("email")):
-            logger.warning(f"User {user_info.get('email')} domain not allowed")
+            logger.warning(
+                "User %s domain not allowed", user_info.get("email")
+            )
             return JSONResponse(
                 status_code=403,
-                content={"detail": "Access denied: Your domain is not authorized"}
+                content={"detail": "Access denied: Your domain is not authorized"},
             )
-        
+
+        # Table Storage 기반 접근 제어 + 역할 조회 (화이트리스트 통합)
+        try:
+            role = await role_service.get_or_assign_role(user_info)
+        except Exception as e:
+            logger.error("Failed to resolve user role: %s", e)
+            role = None
+
+        if not role:
+            logger.warning(
+                "User %s is not registered in the portal",
+                user_info.get("email"),
+            )
+            return JSONResponse(
+                status_code=403,
+                content={
+                    "detail": "Access denied: You are not authorized to use this portal"
+                },
+            )
+
+        user_info["role"] = role
+
         request.state.user = user_info
         request.state.token_claims = claims
-        
-        response = await call_next(request)
-        return response
-    
-    def _is_public_path(self, path: str) -> bool:
-        """Check if path is in public paths list"""
-        for public_path in PUBLIC_PATHS:
-            if path.startswith(public_path):
-                return True
-        return False
+
+        return await call_next(request)
+
+    @staticmethod
+    def _is_public_path(path: str) -> bool:
+        """경로가 공개 경로 목록에 포함되는지 확인한다."""
+        return any(path.startswith(prefix) for prefix in PUBLIC_PATH_PREFIXES)

--- a/backend/app/services/role.py
+++ b/backend/app/services/role.py
@@ -1,0 +1,152 @@
+"""포털 사용자 역할 관리 서비스.
+
+허용된 사용자 목록과 역할을 Table Storage에서 관리한다.
+"""
+import logging
+from datetime import UTC, datetime
+from typing import Any, Optional
+
+from app.exceptions import NotFoundError
+from app.models import UserRole
+
+logger = logging.getLogger(__name__)
+
+
+class RoleService:
+    """포털 사용자 역할을 관리하는 서비스.
+
+    허용된 사용자 목록과 역할을 Table Storage에서 관리한다.
+
+    Attributes:
+        _storage: StorageService 인스턴스 (lazy-loaded).
+    """
+
+    def __init__(self) -> None:
+        self._storage = None
+
+    @property
+    def storage(self):
+        """StorageService 싱글턴을 lazy-load한다."""
+        if self._storage is None:
+            from app.services.storage import storage_service
+
+            self._storage = storage_service
+        return self._storage
+
+    async def get_or_assign_role(
+        self, user_info: dict[str, Any]
+    ) -> Optional[str]:
+        """사용자의 역할을 Table Storage에서 조회한다.
+
+        등록된 사용자는 저장된 역할을 반환하고,
+        미등록 사용자는 None을 반환하여 접근을 거부한다.
+        최초 로그인 시 JWT에서 가져온 이름과 user_id를 보충 저장한다.
+
+        Args:
+            user_info: JWT에서 추출한 사용자 정보 (user_id, name, email).
+
+        Returns:
+            사용자 역할 문자열 ("admin" 또는 "user"), 미등록 시 None.
+        """
+        email = (user_info.get("email") or "").strip().lower()
+        if not email:
+            return None
+
+        stored_user = await self.storage.get_portal_user(email)
+        if not stored_user:
+            return None
+
+        # 최초 로그인 시 JWT에서 가져온 이름·OID를 보충 저장
+        needs_update = False
+        if not stored_user.get("user_id") and user_info.get("user_id"):
+            stored_user["user_id"] = user_info["user_id"]
+            needs_update = True
+        if not stored_user.get("name") and user_info.get("name"):
+            stored_user["name"] = user_info["name"]
+            needs_update = True
+
+        if needs_update:
+            try:
+                await self.storage.save_portal_user(stored_user)
+            except Exception as e:
+                logger.error("Failed to update user profile: %s", e)
+
+        return stored_user.get("role", UserRole.USER.value)
+
+    async def add_user(
+        self, email: str, role: str = "user", name: str = ""
+    ) -> dict[str, Any]:
+        """포털 접근 허용 사용자를 추가한다.
+
+        Args:
+            email: 사용자 이메일.
+            role: 역할 ("admin" 또는 "user").
+            name: 사용자 이름 (선택).
+
+        Returns:
+            저장된 사용자 정보.
+        """
+        user_data = {
+            "user_id": "",
+            "name": name,
+            "email": email.strip().lower(),
+            "role": role,
+            "registered_at": datetime.now(UTC).isoformat(),
+        }
+        await self.storage.save_portal_user(user_data)
+        logger.info("Added portal user: %s (role: %s)", email, role)
+        return user_data
+
+    async def remove_user(self, email: str) -> None:
+        """포털 접근 허용 사용자를 제거한다.
+
+        Args:
+            email: 제거할 사용자 이메일.
+
+        Raises:
+            NotFoundError: 사용자를 찾을 수 없는 경우.
+        """
+        normalized = email.strip().lower()
+        stored_user = await self.storage.get_portal_user(normalized)
+        if not stored_user:
+            raise NotFoundError(
+                f"Portal user '{email}' not found",
+                resource_type="PortalUser",
+            )
+        await self.storage.delete_portal_user(normalized)
+        logger.info("Removed portal user: %s", email)
+
+    async def get_all_users(self) -> list[dict[str, Any]]:
+        """모든 포털 사용자를 조회한다."""
+        return await self.storage.list_portal_users()
+
+    async def update_user_role(
+        self, email: str, new_role: str
+    ) -> dict[str, Any]:
+        """사용자의 역할을 변경한다.
+
+        Args:
+            email: 대상 사용자 이메일.
+            new_role: 새 역할 ("admin" 또는 "user").
+
+        Returns:
+            업데이트된 사용자 정보.
+
+        Raises:
+            NotFoundError: 사용자를 찾을 수 없는 경우.
+        """
+        normalized = email.strip().lower()
+        stored_user = await self.storage.get_portal_user(normalized)
+        if not stored_user:
+            raise NotFoundError(
+                f"Portal user '{email}' not found",
+                resource_type="PortalUser",
+            )
+
+        stored_user["role"] = new_role
+        await self.storage.save_portal_user(stored_user)
+        logger.info("Updated role for user %s to %s", email, new_role)
+        return stored_user
+
+
+role_service = RoleService()

--- a/frontend/src/components/Sidebar/AppSidebar.tsx
+++ b/frontend/src/components/Sidebar/AppSidebar.tsx
@@ -1,5 +1,6 @@
 import { Link as RouterLink, useRouterState } from "@tanstack/react-router"
-import { Cloud, Home, Plus, LogOut, ChevronUp } from "lucide-react"
+import { Home, Plus, LogOut, ChevronUp, Shield, Users, FileCode } from "lucide-react"
+import azureLogo from "@/assets/azure-logo.svg"
 
 import {
   Sidebar,
@@ -28,17 +29,22 @@ interface MenuItem {
   icon: React.ElementType
   title: string
   path: string
+  adminOnly?: boolean
 }
 
 const menuItems: MenuItem[] = [
   { icon: Home, title: "홈", path: "/" },
   { icon: Plus, title: "워크샵 만들기", path: "/workshops/create" },
+  { icon: Users, title: "유저 관리", path: "/users", adminOnly: true },
+  { icon: FileCode, title: "템플릿 관리", path: "/templates", adminOnly: true },
 ]
 
 function MainNav({ items }: { items: MenuItem[] }) {
   const { isMobile, setOpenMobile } = useSidebar()
   const router = useRouterState()
   const currentPath = router.location.pathname
+  const { user } = useAuth()
+  const isAdmin = user?.role === "admin"
 
   const handleMenuClick = () => {
     if (isMobile) {
@@ -46,11 +52,15 @@ function MainNav({ items }: { items: MenuItem[] }) {
     }
   }
 
+  const visibleItems = items.filter(
+    (item) => !item.adminOnly || isAdmin
+  )
+
   return (
     <SidebarGroup>
       <SidebarGroupContent>
         <SidebarMenu>
-          {items.map((item) => {
+          {visibleItems.map((item) => {
             const isActive = currentPath === item.path
 
             return (
@@ -104,6 +114,9 @@ function UserMenu() {
                   {user?.email}
                 </span>
               </div>
+              {user?.role === "admin" && (
+                <Shield className="ml-auto size-4 text-blue-500" />
+              )}
               <ChevronUp className="ml-auto size-4" />
             </SidebarMenuButton>
           </DropdownMenuTrigger>
@@ -126,6 +139,15 @@ function UserMenu() {
                   <span className="truncate text-xs text-muted-foreground">
                     {user?.email}
                   </span>
+                  {user?.role && (
+                    <span className={`mt-0.5 inline-flex w-fit items-center rounded-full px-1.5 py-0.5 text-[10px] font-medium ${
+                      user.role === "admin"
+                        ? "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300"
+                        : "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+                    }`}>
+                      {user.role === "admin" ? "Admin" : "User"}
+                    </span>
+                  )}
                 </div>
               </div>
             </DropdownMenuItem>
@@ -149,8 +171,12 @@ export function AppSidebar() {
           <SidebarMenuItem>
             <SidebarMenuButton size="lg" asChild>
               <RouterLink to="/">
-                <div className="flex aspect-square size-8 items-center justify-center rounded-lg bg-blue-600 text-white">
-                  <Cloud className="size-4" />
+                <div className="flex aspect-square size-8 items-center justify-center rounded-lg">
+                  <img
+                    src={azureLogo}
+                    alt="Azure"
+                    className="size-6"
+                  />
                 </div>
                 <div className="grid flex-1 text-left text-sm leading-tight">
                   <span className="truncate font-semibold">Azure Workshop</span>

--- a/frontend/src/components/ui/alert-dialog.tsx
+++ b/frontend/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,194 @@
+import * as React from "react"
+import { AlertDialog as AlertDialogPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+function AlertDialog({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  )
+}
+
+function AlertDialogPortal({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  )
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content> & {
+  size?: "default" | "sm"
+}) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        data-size={size}
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 group/alert-dialog-content fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-lg",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn(
+        "grid grid-rows-[auto_1fr] place-items-center gap-1.5 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-6 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn(
+        "text-lg font-semibold sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogMedia({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-media"
+      className={cn(
+        "bg-muted mb-2 inline-flex size-16 items-center justify-center rounded-md sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-8",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  variant = "default",
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action> &
+  Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
+  return (
+    <Button variant={variant} size={size} asChild>
+      <AlertDialogPrimitive.Action
+        data-slot="alert-dialog-action"
+        className={cn(className)}
+        {...props}
+      />
+    </Button>
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  variant = "outline",
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel> &
+  Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
+  return (
+    <Button variant={variant} size={size} asChild>
+      <AlertDialogPrimitive.Cancel
+        data-slot="alert-dialog-cancel"
+        className={cn(className)}
+        {...props}
+      />
+    </Button>
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+}

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -12,6 +12,8 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as LayoutRouteImport } from './routes/_layout'
 import { Route as LayoutIndexRouteImport } from './routes/_layout/index'
+import { Route as LayoutUsersRouteImport } from './routes/_layout/users'
+import { Route as LayoutTemplatesRouteImport } from './routes/_layout/templates'
 import { Route as LayoutWorkshopsCreateRouteImport } from './routes/_layout/workshops/create'
 import { Route as LayoutWorkshopsWorkshopIdRouteImport } from './routes/_layout/workshops/$workshopId'
 
@@ -29,6 +31,16 @@ const LayoutIndexRoute = LayoutIndexRouteImport.update({
   path: '/',
   getParentRoute: () => LayoutRoute,
 } as any)
+const LayoutUsersRoute = LayoutUsersRouteImport.update({
+  id: '/users',
+  path: '/users',
+  getParentRoute: () => LayoutRoute,
+} as any)
+const LayoutTemplatesRoute = LayoutTemplatesRouteImport.update({
+  id: '/templates',
+  path: '/templates',
+  getParentRoute: () => LayoutRoute,
+} as any)
 const LayoutWorkshopsCreateRoute = LayoutWorkshopsCreateRouteImport.update({
   id: '/workshops/create',
   path: '/workshops/create',
@@ -44,11 +56,15 @@ const LayoutWorkshopsWorkshopIdRoute =
 export interface FileRoutesByFullPath {
   '/': typeof LayoutIndexRoute
   '/login': typeof LoginRoute
+  '/templates': typeof LayoutTemplatesRoute
+  '/users': typeof LayoutUsersRoute
   '/workshops/$workshopId': typeof LayoutWorkshopsWorkshopIdRoute
   '/workshops/create': typeof LayoutWorkshopsCreateRoute
 }
 export interface FileRoutesByTo {
   '/login': typeof LoginRoute
+  '/templates': typeof LayoutTemplatesRoute
+  '/users': typeof LayoutUsersRoute
   '/': typeof LayoutIndexRoute
   '/workshops/$workshopId': typeof LayoutWorkshopsWorkshopIdRoute
   '/workshops/create': typeof LayoutWorkshopsCreateRoute
@@ -57,19 +73,35 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/_layout': typeof LayoutRouteWithChildren
   '/login': typeof LoginRoute
+  '/_layout/templates': typeof LayoutTemplatesRoute
+  '/_layout/users': typeof LayoutUsersRoute
   '/_layout/': typeof LayoutIndexRoute
   '/_layout/workshops/$workshopId': typeof LayoutWorkshopsWorkshopIdRoute
   '/_layout/workshops/create': typeof LayoutWorkshopsCreateRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/login' | '/workshops/$workshopId' | '/workshops/create'
+  fullPaths:
+    | '/'
+    | '/login'
+    | '/templates'
+    | '/users'
+    | '/workshops/$workshopId'
+    | '/workshops/create'
   fileRoutesByTo: FileRoutesByTo
-  to: '/login' | '/' | '/workshops/$workshopId' | '/workshops/create'
+  to:
+    | '/login'
+    | '/templates'
+    | '/users'
+    | '/'
+    | '/workshops/$workshopId'
+    | '/workshops/create'
   id:
     | '__root__'
     | '/_layout'
     | '/login'
+    | '/_layout/templates'
+    | '/_layout/users'
     | '/_layout/'
     | '/_layout/workshops/$workshopId'
     | '/_layout/workshops/create'
@@ -103,6 +135,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LayoutIndexRouteImport
       parentRoute: typeof LayoutRoute
     }
+    '/_layout/users': {
+      id: '/_layout/users'
+      path: '/users'
+      fullPath: '/users'
+      preLoaderRoute: typeof LayoutUsersRouteImport
+      parentRoute: typeof LayoutRoute
+    }
+    '/_layout/templates': {
+      id: '/_layout/templates'
+      path: '/templates'
+      fullPath: '/templates'
+      preLoaderRoute: typeof LayoutTemplatesRouteImport
+      parentRoute: typeof LayoutRoute
+    }
     '/_layout/workshops/create': {
       id: '/_layout/workshops/create'
       path: '/workshops/create'
@@ -121,12 +167,16 @@ declare module '@tanstack/react-router' {
 }
 
 interface LayoutRouteChildren {
+  LayoutTemplatesRoute: typeof LayoutTemplatesRoute
+  LayoutUsersRoute: typeof LayoutUsersRoute
   LayoutIndexRoute: typeof LayoutIndexRoute
   LayoutWorkshopsWorkshopIdRoute: typeof LayoutWorkshopsWorkshopIdRoute
   LayoutWorkshopsCreateRoute: typeof LayoutWorkshopsCreateRoute
 }
 
 const LayoutRouteChildren: LayoutRouteChildren = {
+  LayoutTemplatesRoute: LayoutTemplatesRoute,
+  LayoutUsersRoute: LayoutUsersRoute,
   LayoutIndexRoute: LayoutIndexRoute,
   LayoutWorkshopsWorkshopIdRoute: LayoutWorkshopsWorkshopIdRoute,
   LayoutWorkshopsCreateRoute: LayoutWorkshopsCreateRoute,

--- a/frontend/src/routes/_layout/users.tsx
+++ b/frontend/src/routes/_layout/users.tsx
@@ -1,0 +1,421 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { useState, useEffect, useCallback } from "react"
+import { UserPlus, Trash2, Shield, User } from "lucide-react"
+
+import { authApi, type PortalUser, type UserRole } from "@/client"
+import useAuth from "@/hooks/useAuth"
+import useCustomToast from "@/hooks/useCustomToast"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
+
+export const Route = createFileRoute("/_layout/users")({
+  component: UserManagementPage,
+})
+
+/** Role badge color mapping. */
+const ROLE_BADGE_STYLES: Record<UserRole, string> = {
+  admin: "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300",
+  user: "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-300",
+}
+
+/** Role display labels. */
+const ROLE_LABELS: Record<UserRole, string> = {
+  admin: "관리자",
+  user: "사용자",
+}
+
+// ---------------------------------------------------------------------------
+// Custom hook: useUsers
+// ---------------------------------------------------------------------------
+
+interface UseUsersResult {
+  users: PortalUser[]
+  isLoading: boolean
+  refetch: () => void
+}
+
+/**
+ * Fetches and manages the portal user list.
+ *
+ * @returns User list, loading state, and refetch function.
+ */
+function useUsers(): UseUsersResult {
+  const [users, setUsers] = useState<PortalUser[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+
+  const fetchUsers = useCallback(async () => {
+    setIsLoading(true)
+    try {
+      const data = await authApi.listUsers()
+      setUsers(data)
+    } catch {
+      setUsers([])
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchUsers()
+  }, [fetchUsers])
+
+  return { users, isLoading, refetch: fetchUsers }
+}
+
+// ---------------------------------------------------------------------------
+// Add‑user dialog (inline card)
+// ---------------------------------------------------------------------------
+
+interface AddUserFormProps {
+  onSubmit: (email: string, role: UserRole, name: string) => void
+  onCancel: () => void
+}
+
+/** Inline form for adding a new portal user. */
+function AddUserForm({ onSubmit, onCancel }: AddUserFormProps) {
+  const [email, setEmail] = useState("")
+  const [name, setName] = useState("")
+  const [role, setRole] = useState<UserRole>("user")
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    onSubmit(email.trim(), role, name.trim())
+  }
+
+  return (
+    <Card className="mb-6">
+      <CardHeader>
+        <CardTitle className="text-lg">새 사용자 추가</CardTitle>
+        <CardDescription>포털에 새 사용자를 추가합니다.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <div className="grid gap-4 sm:grid-cols-3">
+            <div className="space-y-2">
+              <Label htmlFor="add-email">이메일</Label>
+              <Input
+                id="add-email"
+                type="email"
+                placeholder="user@example.com"
+                required
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="add-name">이름</Label>
+              <Input
+                id="add-name"
+                placeholder="홍길동"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="add-role">역할</Label>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    id="add-role"
+                    variant="outline"
+                    className="w-full justify-start"
+                  >
+                    {ROLE_LABELS[role]}
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent>
+                  <DropdownMenuItem onClick={() => setRole("user")}>
+                    <User className="mr-2 h-4 w-4" />
+                    사용자
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => setRole("admin")}>
+                    <Shield className="mr-2 h-4 w-4" />
+                    관리자
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+          </div>
+          <div className="flex gap-2 justify-end">
+            <Button type="button" variant="ghost" onClick={onCancel}>
+              취소
+            </Button>
+            <Button type="submit">추가</Button>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// User table row
+// ---------------------------------------------------------------------------
+
+interface UserRowProps {
+  portalUser: PortalUser
+  currentEmail: string | undefined
+  onRoleChange: (email: string, newRole: UserRole) => void
+  onDelete: (email: string) => void
+}
+
+/** Single row in the user table. */
+function UserRow({ portalUser, currentEmail, onRoleChange, onDelete }: UserRowProps) {
+  const isSelf = portalUser.email === currentEmail
+  const nextRole: UserRole = portalUser.role === "admin" ? "user" : "admin"
+
+  return (
+    <tr className="border-b last:border-b-0 hover:bg-muted/50 transition-colors">
+      <td className="px-4 py-3 text-sm">{portalUser.name || "-"}</td>
+      <td className="px-4 py-3 text-sm">{portalUser.email}</td>
+      <td className="px-4 py-3 text-sm">
+        <span
+          className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${ROLE_BADGE_STYLES[portalUser.role]}`}
+        >
+          {ROLE_LABELS[portalUser.role]}
+        </span>
+      </td>
+      <td className="px-4 py-3 text-sm text-muted-foreground">
+        {new Date(portalUser.registered_at).toLocaleDateString("ko-KR", {
+          year: "numeric",
+          month: "short",
+          day: "numeric",
+        })}
+      </td>
+      <td className="px-4 py-3 text-sm">
+        <div className="flex items-center gap-2">
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={isSelf}
+                title={isSelf ? "자기 자신의 역할은 변경할 수 없습니다" : `역할을 ${ROLE_LABELS[nextRole]}(으)로 변경`}
+              >
+                {nextRole === "admin" ? (
+                  <Shield className="h-3.5 w-3.5 mr-1" />
+                ) : (
+                  <User className="h-3.5 w-3.5 mr-1" />
+                )}
+                {ROLE_LABELS[nextRole]}
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>권한 변경</AlertDialogTitle>
+                <AlertDialogDescription>
+                  <strong>{portalUser.name || portalUser.email}</strong>의 역할을{" "}
+                  <strong>{ROLE_LABELS[portalUser.role]}</strong>에서{" "}
+                  <strong>{ROLE_LABELS[nextRole]}</strong>(으)로 변경하시겠습니까?
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>취소</AlertDialogCancel>
+                <AlertDialogAction onClick={() => onRoleChange(portalUser.email, nextRole)}>
+                  변경
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                disabled={isSelf}
+                title={isSelf ? "자기 자신은 삭제할 수 없습니다" : "사용자 삭제"}
+              >
+                <Trash2 className="h-3.5 w-3.5 text-destructive" />
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>사용자 삭제</AlertDialogTitle>
+                <AlertDialogDescription>
+                  <strong>{portalUser.name || portalUser.email}</strong> 사용자를
+                  정말 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>취소</AlertDialogCancel>
+                <AlertDialogAction
+                  className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                  onClick={() => onDelete(portalUser.email)}
+                >
+                  삭제
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </div>
+      </td>
+    </tr>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Main page
+// ---------------------------------------------------------------------------
+
+/** Admin-only user management page. */
+function UserManagementPage() {
+  const { user, isLoading: authLoading } = useAuth()
+  const { users, isLoading, refetch } = useUsers()
+  const { showSuccessToast, showErrorToast } = useCustomToast()
+  const [showAddForm, setShowAddForm] = useState(false)
+
+  const isAdmin = user?.role === "admin"
+
+  // Guard: show loading while auth/role is being resolved
+  if (authLoading) {
+    return (
+      <div className="flex flex-col items-center justify-center py-20">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent mb-4" />
+        <p className="text-muted-foreground">권한을 확인하는 중입니다…</p>
+      </div>
+    )
+  }
+
+  // Guard: non-admin users see an unauthorized message
+  if (!isAdmin) {
+    return (
+      <div className="flex flex-col items-center justify-center py-20">
+        <Shield className="h-12 w-12 text-muted-foreground mb-4" />
+        <h2 className="text-xl font-semibold mb-2">접근 권한이 없습니다</h2>
+        <p className="text-muted-foreground">
+          이 페이지는 관리자만 접근할 수 있습니다.
+        </p>
+      </div>
+    )
+  }
+
+  const handleAddUser = async (email: string, role: UserRole, name: string) => {
+    try {
+      await authApi.addUser(email, role, name)
+      showSuccessToast(`${email} 사용자가 추가되었습니다.`)
+      setShowAddForm(false)
+      refetch()
+    } catch {
+      showErrorToast("사용자 추가에 실패했습니다.")
+    }
+  }
+
+  const handleRoleChange = async (email: string, newRole: UserRole) => {
+    try {
+      await authApi.updateUserRole(email, newRole)
+      showSuccessToast(`${email}의 역할이 ${ROLE_LABELS[newRole]}(으)로 변경되었습니다.`)
+      refetch()
+    } catch {
+      showErrorToast("역할 변경에 실패했습니다.")
+    }
+  }
+
+  const handleDeleteUser = async (email: string) => {
+    try {
+      await authApi.removeUser(email)
+      showSuccessToast(`${email} 사용자가 삭제되었습니다.`)
+      refetch()
+    } catch {
+      showErrorToast("사용자 삭제에 실패했습니다.")
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">유저 관리</h1>
+          <p className="text-muted-foreground">
+            포털 사용자를 관리합니다.
+          </p>
+        </div>
+        {!showAddForm && (
+          <Button onClick={() => setShowAddForm(true)}>
+            <UserPlus className="h-4 w-4 mr-2" />
+            사용자 추가
+          </Button>
+        )}
+      </div>
+
+      {showAddForm && (
+        <AddUserForm
+          onSubmit={handleAddUser}
+          onCancel={() => setShowAddForm(false)}
+        />
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>사용자 목록</CardTitle>
+          <CardDescription>
+            총 {users.length}명의 사용자가 등록되어 있습니다.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className="space-y-3">
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="h-10 bg-muted rounded animate-pulse" />
+              ))}
+            </div>
+          ) : users.length === 0 ? (
+            <p className="text-center text-muted-foreground py-8">
+              등록된 사용자가 없습니다.
+            </p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full">
+                <thead>
+                  <tr className="border-b text-left text-sm font-medium text-muted-foreground">
+                    <th className="px-4 py-3">이름</th>
+                    <th className="px-4 py-3">이메일</th>
+                    <th className="px-4 py-3">역할</th>
+                    <th className="px-4 py-3">등록일</th>
+                    <th className="px-4 py-3">액션</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {users.map((portalUser) => (
+                    <UserRow
+                      key={portalUser.email}
+                      portalUser={portalUser}
+                      currentEmail={user?.email}
+                      onRoleChange={handleRoleChange}
+                      onDelete={handleDeleteUser}
+                    />
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}


### PR DESCRIPTION
## Issue
close #5
close #7

## Contents
- Backend: RoleService 추가 (역할 조회/변경/추가/삭제)
- Backend: /api/auth/users CRUD 엔드포인트 구현 (Admin 전용)
- Backend: AuthMiddleware에 Table Storage 기반 역할 조회 통합
- Frontend: 유저 관리 페이지 (사용자 목록, 권한 변경 UI)
- Frontend: 사이드바에 유저 관리 메뉴 추가 (Admin 전용)
- Frontend: AlertDialog 컴포넌트 추가 (권한 변경/삭제 확인) 